### PR TITLE
Add IPC messaging between sandbox and shovel, and fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A nifty javascript sandbox for node.js.
 - Handles errors gracefully
 - Restricted code (cannot access node.js methods)
 - Supports `console.log` and `print` utility methods
+- Supports interprocess messaging with the sandboxed code
 
 
 ## Example
@@ -55,6 +56,39 @@ The resulting output object is:
   console: ["20", "22"]
 }
 ```
+
+### `Sandbox`#`postMessage`(`message`)
+
+* `message` {`String`} - message to send to the sandboxed code
+
+For example, the following code will send a message from outside of the sandbox in
+and then the sandboxed code will respond with its own message. Note that the sandboxed
+code handles incoming messages by defining a global `onmessage` function and can
+send messages to the outside using the `postMessage` function.
+
+Sandboxed code:
+```javascript
+onmessage = function(message){
+  if (message === 'hello from outside') {
+    postMessage('hello from inside');
+  }
+};
+```
+
+Sandbox:
+```
+var sandbox = new Sandbox();
+sandbox.run(sandboxed_code);
+sandbox.on('message', function(message){
+  // Handle message sent from the inside
+  // In this example message will be 'hello from inside'
+});
+sandbox.postMessage('hello from outside');
+```
+
+The process will ONLY be considered finished if `onmessage` is NOT a function.
+If `onmessage` is defined the sandbox will assume that it is waiting for an
+incoming message.
 
 
 ## Installation & Running

--- a/example/example.js
+++ b/example/example.js
@@ -51,3 +51,14 @@ s.run( "var x = 5; console.log(x * x); x", function( output ) {
   console.log( "Example 10: " + output.console + "\n" )
 })
 
+// Example 11 - IPC Messaging
+s.run( "onmessage = function(message){ if (message === 'hello from outside') { postMessage('hello from inside'); };", function(output){
+  
+})
+s.on('message', function(message){
+  console.log("Example 11: received message sent from inside the sandbox '" + message + "'\n")
+});
+var test_message = "hello from outside";
+console.log("Example 11: sending message into the sandbox '" + test_message + "'");
+s.postMessage(test_message);
+

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -2,18 +2,35 @@
 // Init
 //-----------------------------------------------------------------------------
 
-var fs    = require('fs');
-var path  = require('path');
-var spawn = require('child_process').spawn;
-
+var fs           = require('fs');
+var path         = require('path');
+var spawn        = require('child_process').spawn;
+var util         = require('util');
+var EventEmitter = require('events').EventEmitter;
 
 //-----------------------------------------------------------------------------
 // Constructor
 //-----------------------------------------------------------------------------
 
 function Sandbox(options) {
-  (this.options = options || {}).__proto__ = Sandbox.options;
+  var self = this;
+  
+  // message_queue is used to store messages that are meant to be sent
+  // to the sandbox before the sandbox is ready to process them
+  self._ready = false;
+  self._message_queue = [];
+  
+  self.options = {
+    timeout: 500,
+    node:    'node',
+    shovel:  path.join(__dirname, 'shovel.js')
+  };
+
+  self.info = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json')));
 }
+
+// Make the Sandbox class an event emitter to handle messages
+util.inherits(Sandbox, EventEmitter);
 
 
 //-----------------------------------------------------------------------------
@@ -21,59 +38,84 @@ function Sandbox(options) {
 //-----------------------------------------------------------------------------
 
 Sandbox.prototype.run = function(code, hollaback) {
+  var self = this;
   var timer;
   var stdout = '';
-  var child  = spawn(this.options.node, [this.options.shovel]);
+  self.child = spawn(this.options.node, [this.options.shovel], { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] });
   var output = function(data) {
-    if (!!data)
+    if (!!data) {
       stdout += data;
+    }
   };
 
-  if (typeof hollaback == 'undefined')
+  if (typeof hollaback == 'undefined') {
     hollaback = console.log;
-  else
+  } else {
     hollaback = hollaback.bind(this);
+  }
 
   // Listen
-  child.stdout.on('data', output);
-  child.on('exit', function(code) {
+  self.child.stdout.on('data', output);
+
+  // Pass messages out from child process
+  // These messages can be handled by Sandbox.on('message', function(message){...});
+  self.child.on('message', function(message){
+    if (message === '__sandbox_inner_ready__') {
+      
+      self.emit('ready');
+      self._ready = true;
+      
+      // Process the _message_queue
+      while(self._message_queue.length > 0) {
+        self.postMessage(self._message_queue.shift());
+      }
+
+    } else {
+      self.emit('message', message);
+    }
+  });
+  
+  self.child.on('exit', function(code) {
     clearTimeout(timer);
     setImmediate(function(){
-      if (!code && !stdout)
+      if (!stdout) {
         hollaback({ result: 'Error', console: [] });
-      else
-        hollaback(JSON.parse(stdout));
+      } else {
+        var ret;
+        try {
+          ret = JSON.parse(stdout);
+        } catch (e) {
+          ret = { result: 'JSON Error (data was "'+stdout+'")', console: [] }
+        }
+        hollaback(ret);
+      }
     });
   });
 
   // Go
-  child.stdin.write(code);
-  child.stdin.end();
+  self.child.stdin.write(code);
+  self.child.stdin.end();
+  
   timer = setTimeout(function() {
-    child.stdout.removeListener('output', output);
+    self.child.stdout.removeListener('output', output);
     stdout = JSON.stringify({ result: 'TimeoutError', console: [] });
-    child.kill('SIGKILL');
-  }, this.options.timeout);
+    self.child.kill('SIGKILL');
+  }, self.options.timeout);
 };
 
-
-//-----------------------------------------------------------------------------
-// Class Properties
-//-----------------------------------------------------------------------------
-
-Sandbox.options = {
-  timeout: 500,
-  node:    'node',
-  shovel:  path.join(__dirname, 'shovel.js')
+// Send a message to the code running inside the sandbox
+// This message will be passed to the sandboxed 
+// code's `onmessage` function, if defined.
+// Messages posted before the sandbox is ready will be queued
+Sandbox.prototype.postMessage = function(message) {
+  var self = this;
+  
+  if (self._ready) {
+    self.child.send(message);
+  } else {
+    self._message_queue.push(message);
+  }
 };
-
-fs.readFile(path.join(__dirname, '..', 'package.json'), function(err, data) {
-  if (err)
-    throw err;
-  else
-    Sandbox.info = JSON.parse(data);
-});
-
 
 //-----------------------------------------------------------------------------
 // Export

--- a/lib/shovel.js
+++ b/lib/shovel.js
@@ -1,28 +1,16 @@
-//-----------------------------------------------------------------------------
-// Init
-//-----------------------------------------------------------------------------
-
-var util = require('util')
-var code;
-var result;
-var console;
-var sandbox;
-var Script;
-var stdin;
-
-if (!(Script = process.binding( 'evals').NodeScript))
-  if (!(Script = process.binding('evals').Script))
-    Script = require('vm');
-
+var util = require('util');
+var vm   = require('vm');
 
 //-----------------------------------------------------------------------------
 // Sandbox
 //-----------------------------------------------------------------------------
 
+var code    = '';
+var stdin   = process.openStdin();
+var result;
+var console = [];
+
 // Get code
-console = [];
-code    = '';
-stdin   = process.openStdin();
 stdin.on('data', function(data) {
   code += data;
 });
@@ -45,20 +33,27 @@ function getSafeRunner() {
       // All comm must be serialized properly to avoid attacks, JSON or XJSON
       //
       comm.send(event, JSON.stringify([].slice.call(arguments,1)));
-    }
+    };
+
     global.print = send.bind(global, 'stdout');
     global.console = { log: send.bind(global, 'stdout') };
-    global.process = { stdout: { write: send.bind(global, 'stdout') } };
+    global.process = { 
+      stdout: { write: send.bind(global, 'stdout') }
+    };
+    global.postMessage = send.bind(global, 'message');
+
+    // This is where the user's source code is actually evaluated
     var result = UserScript(src)();
     send('end', result);
   }
-}
+};
 
 // Run code
 function run() {
-  var context = Script.createContext();
-  var safeRunner = Script.runInContext('('+getSafeRunner.toString()+')()', context);
-  var result;
+
+  var context = vm.createContext();
+  var safeRunner = vm.runInContext('('+getSafeRunner.toString()+')()', context);
+  
   try {
     safeRunner({
       send: function (event, value) {
@@ -71,7 +66,15 @@ function run() {
           case 'end':
             result = JSON.parse(value)[0];
             break;
+          case 'message':
+            process.send(JSON.parse(value)[0]);
+            break;
+          default:
+            throw new Error('Unknown event type');
         }
+      },
+      exit: function(){
+        processExit();
       }
     }, code);
   }
@@ -80,9 +83,31 @@ function run() {
     // throw e;
   }
 
-  process.stdout.on('drain', function() {
+  process.on('message', processMessageListener.bind(null, context));
+  
+  process.send('__sandbox_inner_ready__');
+
+  // This will exit the process if onmessage was not defined
+  checkIfProcessFinished(context);
+};
+
+function processMessageListener(context, message){
+  vm.runInContext('if (typeof onmessage === "function") { onmessage('+ JSON.stringify(String(message)) + '); }', context);
+  checkIfProcessFinished(context);
+};
+
+function checkIfProcessFinished(context) {
+  if(vm.runInContext('typeof onmessage', context) !== 'function') {
+    processExit();
+  }
+};
+
+function processExit() {
+  process.removeListener('message', processMessageListener);
+
+  process.stdout.on('finish', function() {
     process.exit(0);
   });
 
-  process.stdout.write(JSON.stringify({ result: util.inspect(result), console: console }));
-}
+  process.stdout.end(JSON.stringify({ result: util.inspect(result), console: console }));
+};

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "node >=0.5.0"
   ],
   "devDependencies": {
-    "mocha": "1.3.0",
-    "should": "0.6.3"
+    "mocha": "1.20.1",
+    "should": "0.6.3",
+    "sinon": "~1.10.2"
   },
   "repository": {
     "type": "git",

--- a/test/sandbox.js
+++ b/test/sandbox.js
@@ -3,15 +3,18 @@
 //-----------------------------------------------------------------------------
 
 var should  = require('should');
+var sinon   = require('sinon');
 var Sandbox = require('../lib/sandbox');
-var sb      = new Sandbox();
-
 
 //-----------------------------------------------------------------------------
 // Tests
 //-----------------------------------------------------------------------------
 
 describe('Sandbox', function() {
+  var sb;
+  beforeEach(function(){
+    sb = new Sandbox();
+  });
 
   it('should execute basic javascript', function(done) {
     sb.run('1 + 1', function(output) {
@@ -70,6 +73,46 @@ describe('Sandbox', function() {
       output.console[0].should.eql('first');
       output.console[1].should.eql('second');
       done();
+    });
+  });
+
+  it('should expose the postMessage command to the sandboxed code', function(done){
+    var messageHandler = sinon.spy();
+    sb.on('message', messageHandler);
+    sb.run('postMessage("Hello World!");', function(output){
+      messageHandler.calledOnce.should.eql(true);
+      messageHandler.calledWith('Hello World!').should.eql(true);
+      done();
+    });
+  });
+
+  it('should allow sandboxed code to receive messages sent by postMessage from the outside by overwriting the onmessage function', function(done){
+    var messageHandler = sinon.spy();
+    sb.on('message', messageHandler);
+    sb.on('ready', function () {
+      sb.postMessage('Hello World!');
+    });
+    sb.run('onmessage = function (msg) { postMessage(msg); };', function(output) {
+      messageHandler.callCount.should.eql(1);
+      messageHandler.calledWith('Hello World!').should.eql(true);
+      done();
+    });
+  });
+  
+  it('should queue messages posted before the sandbox is ready and process them once it is', function(done){
+    var messageHandler = sinon.spy();
+    var num_messages_sent = 0;
+    var interval = setInterval(function(){
+      sb.postMessage(++num_messages_sent);
+    }, 1);
+    sb.on('message', messageHandler);
+    sb.run('onmessage = function (msg) { postMessage(msg); };', function(output) {
+      messageHandler.callCount.should.eql(num_messages_sent);
+      num_messages_sent.should.be.greaterThan(0);
+      done();
+    });
+    sb.on('ready', function(){
+      clearInterval(interval);
     });
   });
 


### PR DESCRIPTION
Sandbox.postMessage sends messages through to the sandboxed code
User code can handle incoming messages by defining global `onmessage` function
User code can send messages through to the outside of the sandbox by using global `postMessage` function
Sandbox.on('message', function(message){...}) can be used to handle messages sent by sandboxed code
Added tests, example, and documentation
