### PR TITLE
Handling timeout with multiple child processes.

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -96,11 +96,13 @@ Sandbox.prototype.run = function(code, hollaback) {
   self.child.stdin.write(code);
   self.child.stdin.end();
   
-  timer = setTimeout(function() {
-    self.child.stdout.removeListener('output', output);
+  self.child.timer = setTimeout(function() {
+    this.parent.stdout.removeListener('output', output);
     stdout = JSON.stringify({ result: 'TimeoutError', console: [] });
-    self.child.kill('SIGKILL');
+    this.parent.kill('SIGKILL');
   }, self.options.timeout);
+  self.child.timer.parent = self.child;
+
 };
 
 // Send a message to the code running inside the sandbox


### PR DESCRIPTION
Timeout is not functioning in cases, where `run()` is called multiple times on a single instance of Sandbox. The `example.js` is one such case - if you just clone the repo and run the example, as suggested in the readme, the example #5 never finishes and the example keeps hanging. 

I'm suggesting to fix this by attaching the timer directly to the child process. Therefore, the child process can be accessed from the Timeout callback function and terminated properly.
